### PR TITLE
added logging endpoint

### DIFF
--- a/apps/api/src/modules/container/index.ts
+++ b/apps/api/src/modules/container/index.ts
@@ -87,6 +87,21 @@ export const container = new Elysia({ prefix: "/container" })
         500: ContainerModel.response,
       },
     }
+  ).get(
+    "/:id/logs",
+    ({ params }) => {
+      return ContainerService.getLogs(params.id);
+    },
+    {
+      params: t.Object({
+        id: t.String(),
+      }),
+      response: {
+        200: ContainerModel.responseLogs,
+        404: ContainerModel.response,
+        500: ContainerModel.response,
+      },
+    }
   )
   .get(
     "/list",

--- a/apps/api/src/modules/container/model.ts
+++ b/apps/api/src/modules/container/model.ts
@@ -57,6 +57,11 @@ export namespace ContainerModel {
   export const response = t.String()
   export type response = typeof response.static
 
+  export const responseLogs = t.Object({
+    logs: t.String()
+  })
+  export type responseLogs = typeof responseId.static
+
   export const responseId = t.Object({
     id: t.String()
   })

--- a/apps/api/src/modules/container/model.ts
+++ b/apps/api/src/modules/container/model.ts
@@ -60,7 +60,7 @@ export namespace ContainerModel {
   export const responseLogs = t.Object({
     logs: t.String()
   })
-  export type responseLogs = typeof responseId.static
+  export type responseLogs = typeof responseLogs.static
 
   export const responseId = t.Object({
     id: t.String()

--- a/apps/api/src/modules/container/service.ts
+++ b/apps/api/src/modules/container/service.ts
@@ -271,7 +271,7 @@ export class ContainerService {
     tail: number = 50
   ) {
     await this.verifyDockerConnection()
-    console.info(`Getting logs for container with ID: ${containerId}`)
+    console.info(`Getting logs for container with ID: ${containerId}, stdout: ${stdout}, stderr: ${stderr}, tail: ${tail}`)
     const container = docker.getContainer(containerId)
     try {
       const logStream = await container.logs({ tail, stdout, stderr })

--- a/apps/api/src/modules/container/service.ts
+++ b/apps/api/src/modules/container/service.ts
@@ -263,4 +263,23 @@ export class ContainerService {
     )
     return await Promise.all(containerInfos);
   }
+
+  static async getLogs(
+    containerId: string,
+    stdout: boolean = true,
+    stderr: boolean = false,
+    tail: number = 50
+  ) {
+    await this.verifyDockerConnection()
+    console.info(`Getting logs for container with ID: ${containerId}`)
+    const container = docker.getContainer(containerId)
+    try {
+      const logStream = await container.logs({ tail, stdout, stderr })
+      const str = logStream.toString('utf-8')
+      return { logs: str }
+    } catch (err) {
+      console.error(`Failed to get logs for container with ID: ${containerId}; ${err}`)
+      throw status(404, `Failed to get logs for container with ID: ${containerId}; ${err}` satisfies ContainerModel.response)
+    }
+  }
 }

--- a/apps/api/src/modules/minecraft/service.ts
+++ b/apps/api/src/modules/minecraft/service.ts
@@ -9,7 +9,7 @@ export class MinecraftService {
     const gamePort = "25565"
 
     const ports: Record<string, string> = {}
-    if (config.port && config.port !== "") {
+    if (config.port) {
       ports[config.port] = gamePort
     } else {
       const nextFreePort = await PortUtils.getPortOrNextFree(gamePort)

--- a/apps/api/src/modules/minecraft/service.ts
+++ b/apps/api/src/modules/minecraft/service.ts
@@ -9,7 +9,7 @@ export class MinecraftService {
     const gamePort = "25565"
 
     const ports: Record<string, string> = {}
-    if (config.port) {
+    if (config.port && config.port !== "") {
       ports[config.port] = gamePort
     } else {
       const nextFreePort = await PortUtils.getPortOrNextFree(gamePort)


### PR DESCRIPTION
This pull request adds a new API endpoint for retrieving logs from a container, improves type safety for the logs response, and includes a small fix in the Minecraft service for port assignment. The main changes are grouped below.

**Container logs API enhancements:**

* Added a new `GET /container/:id/logs` endpoint in `index.ts` to fetch logs for a specific container using its ID.
* Implemented the `getLogs` method in `ContainerService` to retrieve and return container logs, with error handling and Docker connection verification.
* Added a `responseLogs` type and schema to `ContainerModel` for the logs API response.

**Bug fix in Minecraft service:**

* Updated the port assignment logic in `MinecraftService` to only assign a port if `config.port` is non-empty, preventing accidental assignment of empty ports.