### PR TITLE
added exec for managed containers

### DIFF
--- a/apps/api/src/modules/container/index.ts
+++ b/apps/api/src/modules/container/index.ts
@@ -114,8 +114,25 @@ export const container = new Elysia({ prefix: "/container" })
         500: ContainerModel.response,
       },
     }
-  )
-  .get(
+  ).put(
+    "/:id/exec",
+    ({ body, params }) => {
+      return ContainerService.execInContainer(params.id, body.cmd)
+    },
+    {
+      params: t.Object({
+        id: t.String(),
+      }),
+      body: t.Object({
+        cmd: t.Array(t.String()),
+      }),
+      response: {
+        200: ContainerModel.responseExec,
+        404: ContainerModel.response,
+        500: ContainerModel.response,
+      },
+    }
+  ).get(
     "/list",
     ({ query }) => {
       return ContainerService.listContainers(query.all);

--- a/apps/api/src/modules/container/index.ts
+++ b/apps/api/src/modules/container/index.ts
@@ -114,7 +114,7 @@ export const container = new Elysia({ prefix: "/container" })
         500: ContainerModel.response,
       },
     }
-  ).put(
+  ).post(
     "/:id/exec",
     ({ body, params }) => {
       return ContainerService.execInContainer(params.id, body.cmd)

--- a/apps/api/src/modules/container/model.ts
+++ b/apps/api/src/modules/container/model.ts
@@ -57,6 +57,11 @@ export namespace ContainerModel {
   export const response = t.String()
   export type response = typeof response.static
 
+  export const responseExec = t.Object({
+    output: t.String()
+  })
+  export type responseExec = typeof responseExec.static
+
   export const responseLogs = t.Object({
     logs: t.String()
   })


### PR DESCRIPTION
This pull request adds a new API endpoint to allow executing commands inside managed containers and improves security by ensuring that all container operations are restricted to containers managed by the system. The changes include updates to the service layer, model definitions, and API routing.

**New container command execution feature:**

* Added a new `PUT /container/:id/exec` endpoint in `index.ts` to execute commands inside a container, returning the command output.
* Implemented the `execInContainer` method in `ContainerService` to handle command execution, output collection, and error handling.
* Defined a new response model `responseExec` in `model.ts` to standardize the output format of executed commands.

**Container management and security enhancements:**

* Introduced `ensureContainerIsManaged` in `ContainerService` to verify that operations are performed only on containers managed by the system.
* Updated all container operation methods (`getContainer`, `startContainer`, `stopContainer`, `deleteContainer`, `getContainerLogs`) to enforce the managed container check before proceeding. [[1]](diffhunk://#diff-2b87a3130c4a2a878de66beeb02a4adf84787745725e872075291bb135670952R217-R224) [[2]](diffhunk://#diff-2b87a3130c4a2a878de66beeb02a4adf84787745725e872075291bb135670952R238) [[3]](diffhunk://#diff-2b87a3130c4a2a878de66beeb02a4adf84787745725e872075291bb135670952R252) [[4]](diffhunk://#diff-2b87a3130c4a2a878de66beeb02a4adf84787745725e872075291bb135670952R286)